### PR TITLE
[PATCH][EDA-1471] add new examples to connect Wumps web socket and send message

### DIFF
--- a/run_wumpus.js
+++ b/run_wumpus.js
@@ -1,0 +1,47 @@
+const {WebSocket} = require("ws");
+
+
+const socket = new WebSocket(`wss://4yyity02md.execute-api.us-east-1.amazonaws.com/ws?token=${token}`);
+socket.on('open', function open() {
+    socket.on('message',  async function  catchMessage(data) {
+        try{
+            let message = JSON.parse(data);
+            switch (message.event) {
+                case "challenge":
+                    break;
+                case "your_turn":
+                    let responseWebSocket = "";
+                    if(Math.floor(Math.random() * 6) >= 2 ){
+                        responseWebSocket = process_action(message, "MOVE")
+                    }else{
+                        responseWebSocket = process_action(message, "SHOOT")
+                    }
+                    socket.send(responseWebSocket);
+                    break;  
+                case "list_users":
+                    break;
+                case "game_over":
+                    break;
+                default:
+                    break;
+            }
+        }catch(e){
+            console.log("Error : ",e)
+        }
+    });
+});
+
+
+const process_action = (data, action) => {
+    const directions = ["NOTH","SOUTH","EAST","WEST"]
+    return JSON.stringify({
+        action: action, 
+        data: {
+            "game_id": data.data.game_id,
+            "turn_token": data.data.turn_token,
+            "from_row": Math.floor(Math.random() * 18),
+            "from_col": Math.floor(Math.random() * 18),
+            "direction":directions[Math.floor(Math.random() * directions.length)]
+        }
+    })
+}

--- a/run_wumpus.py
+++ b/run_wumpus.py
@@ -1,0 +1,91 @@
+import asyncio
+import json
+from random import (
+    randint,
+    choice
+)
+import sys
+import websockets
+
+
+async def send(websocket, action, data):
+    message = json.dumps(
+        {
+            'action': action,
+            'data': data,
+        }
+    )
+    print(message)
+    await websocket.send(message)
+
+
+async def start(auth_token):
+    uri = "wss://4yyity02md.execute-api.us-east-1.amazonaws.com/ws?token={}".format(auth_token)
+    while True:
+        try:
+            print('connection to {}'.format(uri))
+            async with websockets.connect(uri) as websocket:
+                await play(websocket)
+        except KeyboardInterrupt:
+            print('Exiting...')
+            break
+        except Exception:
+            print('connection error!')
+            time.sleep(3)
+
+
+async def play(websocket):
+    while True:
+        try:
+            request = await websocket.recv()
+            print(f"< {request}")
+            request_data = json.loads(request)
+            if request_data['event'] == 'update_user_list':
+                pass
+            if request_data['event'] == 'gameover':
+                pass
+            if request_data['event'] == 'challenge':
+                # if request_data['data']['opponent'] == 'favoriteopponent':
+                await send(
+                    websocket,
+                    'accept_challenge',
+                    {
+                        'challenge_id': request_data['data']['challenge_id'],
+                    },
+                )
+            if request_data['event'] == 'your_turn':
+                await process_your_turn(websocket, request_data)
+        except KeyboardInterrupt:
+            print('Exiting...')
+            break
+        except Exception as e:
+            print('error {}'.format(str(e)))
+            break  # force login again
+
+
+async def process_your_turn(websocket, request_data):
+    if randint(0, 4) >= 1:
+        await process_action(websocket, "MOVE", request_data)
+    else:
+        await process_action(websocket, "SHOOT", request_data)
+
+async def process_action(websocket, action, request_data):
+
+        await send(
+            websocket,
+            action,
+            {
+                'game_id': request_data['data']['game_id'],
+                'turn_token': request_data['data']['turn_token'],
+                'from_row': randint(0,17),
+                'from_col': randint(0,17),
+                'direction':choice(["NOTH","SOUTH","EAST","WEST"])
+            },
+        )
+
+if __name__ == '__main__':
+    if len(sys.argv) >= 2:
+        auth_token = sys.argv[1]
+        asyncio.get_event_loop().run_until_complete(start(auth_token))
+    else:
+        print('please provide your auth_token')


### PR DESCRIPTION
To complete the Wumpus user manual. We need to create an example of how to connect the bot with the server by web socker. 

So I created two simple examples with the same code in Python and Javascript. These examples create a WebSocket connection, receive messages, and send random moves in the "your turn" event.